### PR TITLE
Add all schedule options

### DIFF
--- a/custom_components/plum_ecomax/services.py
+++ b/custom_components/plum_ecomax/services.py
@@ -44,7 +44,7 @@ PRESET_DAY: Final = "day"
 PRESET_NIGHT: Final = "night"
 PRESETS = (PRESET_DAY, PRESET_NIGHT)
 
-SCHEDULES: Final = ("heating", "water_heater")
+SCHEDULES: Final = ("heating", "water_heater", "circulation_pump", "boiler_work")
 
 SERVICE_GET_PARAMETER = "get_parameter"
 SERVICE_GET_PARAMETER_SCHEMA = make_entity_service_schema(

--- a/custom_components/plum_ecomax/services.yaml
+++ b/custom_components/plum_ecomax/services.yaml
@@ -37,6 +37,8 @@ get_schedule:
           options:
             - "heating"
             - "water_heater"
+            - "circulation_pump"
+            - "boiler_work"
     weekdays:
       example: "monday"
       required: true
@@ -64,6 +66,8 @@ set_schedule:
           options:
             - "heating"
             - "water_heater"
+            - "circulation_pump"
+            - "boiler_work"
     weekdays:
       example: "monday"
       required: true

--- a/custom_components/plum_ecomax/strings.json
+++ b/custom_components/plum_ecomax/strings.json
@@ -554,7 +554,9 @@
     "schedule_type": {
       "options": {
         "heating": "Heating",
-        "water_heater": "Water heater"
+        "water_heater": "Water heater",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/cs.json
+++ b/custom_components/plum_ecomax/translations/cs.json
@@ -551,7 +551,9 @@
     "schedule_type": {
       "options": {
         "heating": "Vytápění",
-        "water_heater": "Ohřev vody"
+        "water_heater": "Ohřev vody",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/en.json
+++ b/custom_components/plum_ecomax/translations/en.json
@@ -554,7 +554,9 @@
     "schedule_type": {
       "options": {
         "heating": "Heating",
-        "water_heater": "Water heater"
+        "water_heater": "Water heater",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/fr.json
+++ b/custom_components/plum_ecomax/translations/fr.json
@@ -551,7 +551,9 @@
     "schedule_type": {
       "options": {
         "heating": "Chauffage",
-        "water_heater": "Chauffe-eau"
+        "water_heater": "Chauffe-eau",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/pl.json
+++ b/custom_components/plum_ecomax/translations/pl.json
@@ -554,7 +554,9 @@
     "schedule_type": {
       "options": {
         "heating": "Grzanie CO",
-        "water_heater": "Grzanie CWU"
+        "water_heater": "Grzanie CWU",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/ru.json
+++ b/custom_components/plum_ecomax/translations/ru.json
@@ -554,7 +554,9 @@
     "schedule_type": {
       "options": {
         "heating": "Отопление",
-        "water_heater": "Водонагреватель"
+        "water_heater": "Водонагреватель",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {

--- a/custom_components/plum_ecomax/translations/ua.json
+++ b/custom_components/plum_ecomax/translations/ua.json
@@ -554,7 +554,9 @@
     "schedule_type": {
       "options": {
         "heating": "Heating",
-        "water_heater": "Water heater"
+        "water_heater": "Water heater",
+        "circulation_pump": "Circulation pump",
+        "boiler_work": "Boiler"
       }
     },
     "sensor_device_class": {


### PR DESCRIPTION
For example EcoMAX360P1 using boiler_work schedule as "main" one in main menu. Switches can be added via custom entity.